### PR TITLE
Added missing comma to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install gitbook-plugin-jsfiddle --save
     "plugins": [ "jsfiddle"],
     "pluginsConfig": {
           "jsfiddle":{
-            "type":"script"
+            "type":"script",
             "tabs":["result","js","css", "html"],
             "height": "500",
             "width": "500",


### PR DESCRIPTION
Missing comma in the pluginsConfig for jsFiddle
